### PR TITLE
feat: Remove all firstParty API restrictions for third-party provider support

### DIFF
--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -1433,7 +1433,6 @@ async function* queryModel(
     if (
       !cacheEditingHeaderLatched &&
       cachedMCEnabled &&
-      getAPIProvider() === 'firstParty' &&
       options.querySource === 'repl_main_thread'
     ) {
       cacheEditingHeaderLatched = true
@@ -1674,11 +1673,9 @@ async function* queryModel(
     // the feature disables but the header doesn't flip.
     const useCachedMC =
       cachedMCEnabled &&
-      getAPIProvider() === 'firstParty' &&
       options.querySource === 'repl_main_thread'
     if (
       cacheEditingHeaderLatched &&
-      getAPIProvider() === 'firstParty' &&
       options.querySource === 'repl_main_thread' &&
       !betasParams.includes(cacheEditingBetaHeader)
     ) {

--- a/src/utils/betas.ts
+++ b/src/utils/betas.ts
@@ -160,12 +160,7 @@ export function modelSupportsStructuredOutputs(model: string): boolean {
 export function modelSupportsAutoMode(model: string): boolean {
   if (feature('TRANSCRIPT_CLASSIFIER')) {
     const m = getCanonicalName(model)
-    // External: firstParty-only at launch (PI probes not wired for
-    // Bedrock/Vertex/Foundry yet). Checked before allowModels so the GB
-    // override can't enable auto mode on unsupported providers.
-    if (process.env.USER_TYPE !== 'ant' && getAPIProvider() !== 'firstParty') {
-      return false
-    }
+    // NOTE: Removed firstParty check to allow custom proxies to use auto mode
     // GrowthBook override: tengu_auto_mode_config.allowModels force-enables
     // auto mode for listed models, bypassing the denylist/allowlist below.
     // Exact model IDs (e.g. "claude-strudel-v6-p") match only that model;
@@ -212,23 +207,14 @@ export function getToolSearchBetaHeader(): string {
  * These are betas that are only available on firstParty provider
  * and may not be supported by proxies or other providers.
  */
+// NOTE: Removed firstParty checks to allow custom proxies to use experimental betas
 export function shouldIncludeFirstPartyOnlyBetas(): boolean {
-  return (
-    (getAPIProvider() === 'firstParty' || getAPIProvider() === 'foundry') &&
-    !isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS)
-  )
+  return !isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS)
 }
 
-/**
- * Global-scope prompt caching is firstParty only. Foundry is excluded because
- * GrowthBook never bucketed Foundry users into the rollout experiment — the
- * treatment data is firstParty-only.
- */
+// NOTE: Removed firstParty check to allow custom proxies to use global cache scope
 export function shouldUseGlobalCacheScope(): boolean {
-  return (
-    getAPIProvider() === 'firstParty' &&
-    !isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS)
-  )
+  return !isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS)
 }
 
 export const getAllModelBetas = memoize((model: string): string[] => {

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -3,7 +3,6 @@ import { isUltrathinkEnabled } from './thinking.js'
 import { getInitialSettings } from './settings/settings.js'
 import { isProSubscriber, isMaxSubscriber, isTeamSubscriber } from './auth.js'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from 'src/services/analytics/growthbook.js'
-import { getAPIProvider } from './model/providers.js'
 import { get3PModelCapabilityOverride } from './model/modelSupportOverrides.js'
 import { isEnvTruthy } from './envUtils.js'
 import type { EffortLevel } from 'src/entrypoints/sdk/runtimeTypes.js'
@@ -42,10 +41,8 @@ export function modelSupportsEffort(model: string): boolean {
   // the model launch DRI and research. This is a sensitive setting that can
   // greatly affect model quality and bashing.
 
-  // Default to true for unknown model strings on 1P.
-  // Do not default to true for 3P as they have different formats for their
-  // model strings (ex. anthropics/claude-code#30795)
-  return getAPIProvider() === 'firstParty'
+  // NOTE: Removed firstParty check to allow custom proxies to use effort
+  return true
 }
 
 // @[MODEL LAUNCH]: Add the new model to the allowlist if it supports 'max' effort.

--- a/src/utils/fastMode.ts
+++ b/src/utils/fastMode.ts
@@ -26,7 +26,6 @@ import {
   type ModelSetting,
   parseUserSpecifiedModel,
 } from './model/model.js'
-import { getAPIProvider } from './model/providers.js'
 import { isEssentialTrafficOnly } from './privacyLevel.js'
 import {
   getInitialSettings,
@@ -109,12 +108,7 @@ export function getFastModeUnavailableReason(): string | null {
     }
   }
 
-  // Only available for 1P (not Bedrock/Vertex/Foundry)
-  if (getAPIProvider() !== 'firstParty') {
-    const reason = 'Fast mode is not available on Bedrock, Vertex, or Foundry'
-    logForDebugging(`Fast mode unavailable: ${reason}`)
-    return reason
-  }
+  // NOTE: Removed firstParty check to allow custom proxies to use fast mode
 
   if (orgStatus.status === 'disabled') {
     if (


### PR DESCRIPTION
## Summary

This PR removes all firstParty API restrictions to enable full functionality for third-party API providers (Kimi, GLM, custom proxies, etc.).

## Changes

### Cache Editing (cachedMicrocompact)
- Removed 3x `getAPIProvider() === 'firstParty'` checks in `services/api/claude.ts`
- Cache editing beta header now available for all providers

### Core Features
- **Fast Mode** (`utils/fastMode.ts`): Removed firstParty restriction
- **Effort** (`utils/effort.ts`): Always enabled
- **Auto Mode** (`utils/betas.ts`): Removed firstParty restriction
- **Task Budget** (`utils/betas.ts`): Via `shouldIncludeFirstPartyOnlyBetas()`
- **AFK Mode** (`utils/betas.ts`): Via `shouldIncludeFirstPartyOnlyBetas()`
- **Advisor Tool** (`utils/advisor.ts`): Via `shouldIncludeFirstPartyOnlyBetas()`
- **Context Management** (`utils/betas.ts`): Via `shouldIncludeFirstPartyOnlyBetas()`
- **Global Cache Scope** (`utils/betas.ts`): Removed firstParty restriction
- **Anti-distillation** (`utils/betas.ts`): Via `shouldIncludeFirstPartyOnlyBetas()`

### Experimental Betas
- Modified `shouldIncludeFirstPartyOnlyBetas()` to allow all providers
- Modified `shouldUseGlobalCacheScope()` to allow all providers

## Notes

- Anthropic internal features (`USER_TYPE === 'ant'`) remain restricted
- Claude.ai subscriber features (`isClaudeAISubscriber()`) remain unchanged
- Bedrock/Vertex/Foundry specific implementations preserved

## Related

Enables full feature parity for third-party API users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded cache editing functionality availability across more configurations
  * Broadened auto-mode enablement eligibility 
  * Extended beta feature accessibility
  * Increased model effort support coverage
  * Updated fast mode availability criteria

<!-- end of auto-generated comment: release notes by coderabbit.ai -->